### PR TITLE
Remove domain name from metric

### DIFF
--- a/asgraphite.py
+++ b/asgraphite.py
@@ -36,6 +36,7 @@ import sys, os, time, atexit
 from signal import SIGTERM
 import fcntl
 import subprocess
+from re import sub
 
 
 class Pidfile(object):
@@ -347,7 +348,7 @@ if not args.stop:
 CITRUSLEAF_SERVER = args.base_node
 CITRUSLEAF_PORT = args.info_port
 CITRUSLEAF_XDR_PORT = args.xdr_port
-CITRUSLEAF_SERVER_ID = socket.gethostname()
+CITRUSLEAF_SERVER_ID = sub('\..*','',socket.gethostname())
 GRAPHITE_PATH_PREFIX = args.graphite_prefix + CITRUSLEAF_SERVER_ID
 INTERVAL = 30
 


### PR DESCRIPTION
On some hosts socket.gethostname() gives just host name on others it returns host name
together with domain name.

The CITRUSLEAF_SERVER_ID should always be just the host name without the domain name,
as the domain name (reversed) can optionally be passed as graphite_prefix.

fixes #7
