### PR TITLE
Support output to stdout

### DIFF
--- a/asgraphite.py
+++ b/asgraphite.py
@@ -192,6 +192,13 @@ class Daemon:
 		self.stop()
 		self.start()
 
+	def once(self):
+		"""
+		Run the process once
+		"""
+		# Start the daemon
+		self.run()
+
 	def run(self):
 		"""
 		You should override this method when you subclass Daemon. It will be called after the process has been
@@ -434,7 +441,14 @@ parser.add_argument("--start"
 					, action="store_true"
 					, dest="start"
 					, help="Start the Daemon")
-
+parser.add_argument("--stdout"
+					, action="store_true"
+					, dest="stdout"
+					, help="Print metrics output to stdout")
+parser.add_argument("--once"
+					, action="store_true"
+					, dest="once"
+					, help="Run the script once")
 parser.add_argument("--restart"
 					, action="store_true"
 					, dest="restart"
@@ -572,7 +586,7 @@ if args.user != None:
 # Configurable parameters
 LOGFILE = args.log_file
 
-if not args.stop:
+if not args.stop and not args.stdout:
 	if args.graphite_server:
 		GRAPHITE_SERVER = args.graphite_server
 	else:
@@ -589,7 +603,8 @@ AEROSPIKE_SERVER = args.base_node
 AEROSPIKE_PORT = args.info_port
 AEROSPIKE_SERVER_ID = socket.gethostname()
 AEROSPIKE_XDR_DCS = args.dc
-GRAPHITE_PATH_PREFIX = args.graphite_prefix + AEROSPIKE_SERVER_ID
+#GRAPHITE_PATH_PREFIX = args.graphite_prefix + AEROSPIKE_SERVER_ID
+GRAPHITE_PATH_PREFIX = ''
 INTERVAL = int(args.graphite_interval)
 
 class clGraphiteDaemon(Daemon):
@@ -608,9 +623,10 @@ class clGraphiteDaemon(Daemon):
 		return s
 
 	def run(self):
-		print "Starting asgraphite daemon" , time.asctime(time.localtime())
-		s = self.connect()
-		print "Aerospike-Graphite connector started: ", time.asctime(time.localtime())
+#		print "Starting asgraphite daemon" , time.asctime(time.localtime())
+		if not args.stdout:
+			s = self.connect()
+#		print "Aerospike-Graphite connector started: ", time.asctime(time.localtime())
 		sys.stdout.flush()
 		while True:
 			msg = []
@@ -845,30 +861,40 @@ class clGraphiteDaemon(Daemon):
 				line = ''
 				for f in fields:
 					line += f + ' '
+				line = line.lstrip('.')
 				nmsg += line + '\n'
-			try:
-				if args.verbose:
-					print nmsg
-				s.sendall(nmsg)
-			except:
-				#Once the connection is broken, we need to reconnect
-				print "ERROR: Unable to send to graphite server, retrying connection.."
-				sys.stdout.flush()
-				s.close()
-				s = self.connect()
-			client.close()
-			time.sleep(INTERVAL)
+			if not args.stdout:
+				try:
+					if args.verbose:
+						print nmsg
+					s.sendall(nmsg)
+				except:
+					#Once the connection is broken, we need to reconnect
+					print "ERROR: Unable to send to graphite server, retrying connection.."
+					sys.stdout.flush()
+					s.close()
+					s = self.connect()
+				client.close()
+			else:
+				print nmsg
+
+			if args.once:
+				break
+			else:
+				time.sleep(INTERVAL)
 
 if __name__ == "__main__":
 	#TODO: move this to config param
 	daemon = clGraphiteDaemon('/tmp/asgraphite.pid', LOGFILE)
-	if args.start or args.stop or args.restart:
+	if args.start or args.stop or args.restart or args.once:
 		if args.start:
 			daemon.start()
 		elif args.stop:
 			daemon.stop()
 		elif args.restart:
 			daemon.restart()
+		elif args.once:
+			daemon.once()
 		else:
 			print "Unknown command"
 			sys.exit(20)

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -441,18 +441,22 @@ parser.add_argument("--start"
 					, action="store_true"
 					, dest="start"
 					, help="Start the Daemon")
+
 parser.add_argument("--stdout"
 					, action="store_true"
 					, dest="stdout"
 					, help="Print metrics output to stdout")
+
 parser.add_argument("--once"
 					, action="store_true"
 					, dest="once"
 					, help="Run the script once")
+
 parser.add_argument("--restart"
 					, action="store_true"
 					, dest="restart"
 					, help="Restart the Daemon")
+
 parser.add_argument("-v"
 					, "--verbose"
 					, action="store_true"
@@ -603,8 +607,7 @@ AEROSPIKE_SERVER = args.base_node
 AEROSPIKE_PORT = args.info_port
 AEROSPIKE_SERVER_ID = socket.gethostname()
 AEROSPIKE_XDR_DCS = args.dc
-#GRAPHITE_PATH_PREFIX = args.graphite_prefix + AEROSPIKE_SERVER_ID
-GRAPHITE_PATH_PREFIX = ''
+GRAPHITE_PATH_PREFIX = args.graphite_prefix + AEROSPIKE_SERVER_ID
 INTERVAL = int(args.graphite_interval)
 
 class clGraphiteDaemon(Daemon):

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -623,10 +623,11 @@ class clGraphiteDaemon(Daemon):
 		return s
 
 	def run(self):
-#		print "Starting asgraphite daemon" , time.asctime(time.localtime())
 		if not args.stdout:
+			print "Starting asgraphite daemon" , time.asctime(time.localtime())
 			s = self.connect()
-#		print "Aerospike-Graphite connector started: ", time.asctime(time.localtime())
+			print "Aerospike-Graphite connector started: ", time.asctime(time.localtime())
+
 		sys.stdout.flush()
 		while True:
 			msg = []


### PR DESCRIPTION
In order to use this as a plugin to an internal statistic agent, we need the data to be sent to STDOUT and to not run as a daemon.

Added argument `--once` that causes the script to run once and then exit.

Added argument `--stdout` that causes the data to be sent to STDOUT instead of connecting to to GRAPHITE_SERVER.