### PR TITLE
Skip dynamic latency groups if no groups exist

### DIFF
--- a/asgraphite.py
+++ b/asgraphite.py
@@ -690,8 +690,9 @@ class clGraphiteDaemon(Daemon):
 								latency_type, rest = string.split(':', 1)
 								# handle dynamic naming
 								match = re.match('{(.*)}',latency_type)
-								latency_type = re.sub('{.*}-','',latency_type)
-								latency_type = match.groups()[0]+'.'+latency_type
+								if match:
+									latency_type = re.sub('{.*}-','',latency_type)
+									latency_type = match.groups()[0]+'.'+latency_type
 								header = rest.split(',')
 							else:
 								val = string.split(',')


### PR DESCRIPTION
Testing against 3.8.4 showed errors in the latency calculations because there was no match.  I assume this is because there are no dynamic groups.  So, if no match, then skip these lines.