### PR TITLE
Tools 1544 1533 make up-to-date with 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,6 @@ An example logrotate file is provided. Move/rename the asgraphite.logrotate into
 This script is not aware of journalctl, as such it is not completely compatible with SystemD OSs. If your OS is a SystemD OS (RedHat 7, Ubuntu 16+), you would need to reinstall logrotate. Otherwise the generated log will grow without end.
 
 ### Dependencies
-- python version 2.6+.<BR>
+- python version 3.4+.<BR>
 - python argparse.<BR>
-- Aerospike Python Client version 3.7.1+.
+- Aerospike Python Client version 3.10.0+.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ For more information see the [Aerospike Python Client Installation page](/docs/c
 
 ### Getting Started
 1. Copy asgraphite.py to /opt/aerospike/bin/asgraphite
-    > The script requires python version 2.6+.<BR>
+    > The script requires python 3.<BR>
     > The script requires python argparse.<BR>
-    > The script requires Aerospike Python Client version 3.7.1+.
+    > The script requires Aerospike Python Client version 3.10.0+.
 1. Ensure the aerospike log directory exists. `/var/log/aerospike/`
 1. Issue the aerospike Graphite command
+1. Ensure asgraphite.py is running properly.
+```
+tail -f /var/log/aerospike/asgraphite.log
+
+Starting asgraphite daemon Tue Aug 18 17:11:10 2020
+Aerospike-Graphite connector started:  Tue Aug 18 17:11:10 2020
+```
 
 ### Usage
 ```bash
@@ -181,6 +188,14 @@ An example logrotate file is provided. Move/rename the asgraphite.logrotate into
 
 **Note**
 This script is not aware of journalctl, as such it is not completely compatible with SystemD OSs. If your OS is a SystemD OS (RedHat 7, Ubuntu 16+), you would need to reinstall logrotate. Otherwise the generated log will grow without end.
+
+### Grafana
+The aerospike dashboard provided uses variables to allow switching between different
+Aerospike clusters. When launching asgraphite.py be sure to provide a --prefix argument 
+to label your clusters appropriately. Example prefix: `aerospike.cluster-west`.
+
+**Note**: Grafana and Aerospike Server both use port 3000 by default.  To run both on the same
+host you will need to change the port used by Grafana in grafana.ini.
 
 ### Dependencies
 - python version 3.4+.<BR>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ optional arguments:
                         CRLs
   --tls-ciphers TLS_CIPHERS
                         Ciphers to include. See https://www.openssl.org/docs/m
-                        an1.0.1/apps/ciphers.html for cipher list format
+                        an1.1.0/man1/ciphers.html for cipher list format
   --tls-protocols TLS_PROTOCOLS
                         The TLS protocol to use. Available choices: TLSv1,
                         TLSv1.1, TLSv1.2, all. An optional + or - can be

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ optional arguments:
                         Path to the credentials file. Use this in place of
                         --user and --password.
   --auth-mode AUTH_MODE
-                        Authentication mode. Values: ['EXTERNAL_INSECURE',
-                        'INTERNAL', 'EXTERNAL'] (default: INTERNAL)
+                        Authentication mode. Values: ['INTERNAL',
+                        'EXTERNAL_INSECURE', 'EXTERNAL'] (default: INTERNAL)
   --stop                Stop the Daemon
   --start               Start the Daemon
   --once                Run the script once
@@ -105,7 +105,7 @@ optional arguments:
   --tls-keyfile TLS_KEYFILE
                         The private keyfile for your client TLS Cert
   --tls-keyfile-pw TLS_KEYFILE_PW
-                        Password to load protected tls_keyfile
+                        Password to load protected tls-keyfile
   --tls-certfile TLS_CERTFILE
                         The client TLS cert
   --tls-cafile TLS_CAFILE
@@ -125,11 +125,9 @@ optional arguments:
                         Blacklist including serial number of certs to revoke
   --tls-crl-check       Checks SSL/TLS certs against vendor's Certificate
                         Revocation Lists for revoked certificates. CRLs are
-                        found in path specified by --tls_capath. Checks the
+                        found in path specified by --tls-capath. Checks the
                         leaf certificates only
   --tls-crl-check-all   Check on all entries within the CRL chain
-
-
 ```
 
 ### Examples

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -666,7 +666,7 @@ class clGraphiteDaemon(Daemon):
                 res = -1
                 latencies_cmds = [ item for sublist in AEROSPIKE_LATENCY_CMDS for item in sublist]
                 try:
-                    use_latencies_cmd = True if int(version[0]) >= 5 and int(version[1]) >= 1 else False
+                    use_latencies_cmd = int(version[0]) >= 5 and int(version[1]) >= 1
                     if use_latencies_cmd:
                         for cmd in latencies_cmds:
                             if cmd.startswith('latencies:'):

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -412,8 +412,10 @@ parser.add_argument("-s"
                     , help="Gather set based statistics")
 parser.add_argument("-l"
                     , "--latency"
+                    , nargs='+'
+                    , action='append'
                     , dest="latency"
-                    , help="Enable latency statistics and specify query (ie. latency:back=70;duration=60)")
+                    , help="Enable latency statistics and specify query (ie. latency:back=70;duration=60 or latencies:hist={NS}-benchmark-write)")
 parser.add_argument("-x"
                     , "--xdr"
                     , nargs='+'
@@ -558,6 +560,7 @@ if not args.stop and not args.stdout:
 AEROSPIKE_SERVER = args.base_node
 AEROSPIKE_PORT = args.info_port
 AEROSPIKE_SERVER_ID = args.hostname
+AEROSPIKE_LATENCY_CMDS = args.latency
 AEROSPIKE_XDR_DCS = args.dc
 GRAPHITE_PATH_PREFIX = args.graphite_prefix + '.' + AEROSPIKE_SERVER_ID
 INTERVAL = int(args.graphite_interval)
@@ -611,12 +614,15 @@ class clGraphiteDaemon(Daemon):
             msg = []
             now = int(time.time())
 
-            r = -1
+            # For checking serer version in order to issue correct commands.
+            version = self.client.info('build').split('.')
+
+            res = -1
             try:
-                r = self.client.info('statistics')
-                if (-1 != r):
+                res = self.client.info('statistics')
+                if (-1 != res):
                     lines = []
-                    for string in r.split(';'):
+                    for string in res.split(';'):
                         if string == "":
                             continue
     
@@ -630,17 +636,17 @@ class clGraphiteDaemon(Daemon):
                     msg.extend(lines)
             except:
                 print("Unable to parse general stats:")
-                print(r)        # not combined with above line because 'r' could be int (-1) or string
+                print(res)        # not combined with above line because 'r' could be int (-1) or string
                 sys.stdout.flush()
 
             if args.sets:
-                r = -1
+                res = -1
                 try:
-                    r = self.client.info('sets')
-                    if (-1 != r):
-                        r = r.strip()
+                    res = self.client.info('sets')
+                    if (-1 != res):
+                        res = res.strip()
                         lines = []
-                        for string in r.split(';'):
+                        for string in res.split(';'):
                             if len(string) == 0:
                                 continue
                             setList = string.split(':')
@@ -652,41 +658,78 @@ class clGraphiteDaemon(Daemon):
                         msg.extend(lines)
                 except Exception as e:
                     print("Unable to parse set stats:")
-                    print(r)
+                    print(res)
                     print(e)
                     sys.stdout.flush()
 
             if args.latency:
-                r = -1
+                res = -1
+                latencies_cmds = [ item for sublist in AEROSPIKE_LATENCY_CMDS for item in sublist]
                 try:
-                    if args.latency.startswith('latency:'):
-                        r = self.client.info(args.latency)
+                    use_latencies_cmd = True if int(version[0]) >= 5 and int(version[1]) >= 1 else False
+                    if use_latencies_cmd:
+                        for cmd in latencies_cmds:
+                            if cmd.startswith('latencies:'):
+                                r = self.client.info(cmd)
+                            else:
+                                print("-latency argument is in an incorrect format.")
+                                print("Running with argument \"latencies:\" instead.")
+                                r = self.client.info('latencies:')
+
+                            if res == -1:
+                                res = r.strip()
+                            else:
+                                res = res + ';' + r.strip()
                     else:
-                        r = self.client.info('latency:')
-                    if (-1 != r):
-                        r = r.strip()
+                        if args.latency.startswith('latency:'):
+                            res = self.client.info(latencies_cmds[0])
+                        else:
+                            print("-latency argument is in an incorrect format.")
+                            print("Running with argument \"latency:\" instead.")
+                            res = self.client.info('latency:')
+                    if (-1 != res):
+                        res = res.strip()
                         lines = []
                         latency_type = ""
                         header = []
-                        for string in r.split(';'):
-                            if len(string) == 0 or string.startswith("error"):
+                        #print(res)
+                        for histogram in res.split(';'):
+                            if len(histogram) == 0 or histogram.startswith("error"):
                                 continue
                             if len(latency_type) == 0:
                                 # Base case
-                                latency_type, rest = string.split(':', 1)
+                                latency_type, rest = histogram.split(':', 1)
                                 # handle dynamic naming
                                 match = re.match('{(.*)}',latency_type)
                                 if match:
                                     latency_type = re.sub('{.*}-','',latency_type)
                                     latency_type = match.groups()[0]+'.'+latency_type
+                                
+                                # Support for latencies (5.1+) cmd which uses a single line per histogram
+                                if use_latencies_cmd:
+                                    # latencies command does not return error, just empty histogram
+                                    if len(rest) == 0:
+                                        continue
+                                    # remove msec
+                                    thresholds = rest.split(',')[1:]
+                                    name = latency_type + "." + 'ops_per_sec'
+                                    value = thresholds[0]
+                                    lines.append("%s.latency.%s %s %s" % (GRAPHITE_PATH_PREFIX , name, value, now))
+                                    for i in range(0, 17):
+                                        name = latency_type + '.over_' + str(2**i) + "ms"
+                                        value = thresholds[i + 1]
+                                        lines.append("%s.latency.%s %s %s" % (GRAPHITE_PATH_PREFIX , name, value, now))
+                                    continue
+           
                                 header = rest.split(',')
+                            # The latency cmd (pre 5.1) uses 2 lines per histogram
                             else:
-                                val = string.split(',')
+                                thresholds = histogram.split(',')
                                 for i in range(1, len(header)):
                                     name = latency_type + "." + header[i]
                                     name = name.replace('>', 'over_')
                                     name = name.replace('ops/sec', 'ops_per_sec')
-                                    value = val[i]
+                                    value = thresholds[i]
                                     lines.append("%s.latency.%s %s %s" % (GRAPHITE_PATH_PREFIX , name, value, now))
                                 # Reset base case
                                 latency_type = ""
@@ -694,25 +737,25 @@ class clGraphiteDaemon(Daemon):
                         msg.extend(lines)
                 except Exception as e:
                     print("Unable to parse latency stats:")
-                    print(r)
+                    print(res)
                     print(e)
                     sys.stdout.flush()
 
             if args.namespace:
-                r = -1
+                res = -1
                 try:
-                    r = self.client.info('namespaces')
-                    if (-1 != r):
-                        r = r.strip()
-                        namespaces = list(filter(None, r.split(';')))
+                    res = self.client.info('namespaces')
+                    if (-1 != res):
+                        res = res.strip()
+                        namespaces = list(filter(None, res.split(';')))
                         if len(namespaces) > 0:
                             for namespace in namespaces:
-                                r = -1
-                                r = self.client.info('namespace/' + namespace)
-                                if (-1 != r):
-                                    r = r.strip()
+                                res = -1
+                                res = self.client.info('namespace/' + namespace)
+                                if (-1 != res):
+                                    res = res.strip()
                                     lines = []
-                                    for string in r.split(';'):
+                                    for string in res.split(';'):
                                         name, value = string.split('=')
                                         value = value.replace('false', "0")
                                         value = value.replace('true', "1")
@@ -723,13 +766,13 @@ class clGraphiteDaemon(Daemon):
                                     HD = [ item for sublist in args.hist_dump for item in sublist]
                                     for histtype in HD:
                                         try:
-                                            r = self.client.info('hist-dump:ns=' + namespace + ';hist=' + histtype)
-                                            if (-1 != r):
-                                                if 'hist-not-applicable' in r:
+                                            res = self.client.info('hist-dump:ns=' + namespace + ';hist=' + histtype)
+                                            if (-1 != res):
+                                                if 'hist-not-applicable' in res:
                                                     continue    # skip in-memory namespaces that don't have histograms
-                                                r = r.strip()
+                                                res = res.strip()
                                                 lines = []
-                                                string, ignore = r.split(';')
+                                                string, ignore = res.split(';')
                                                 namespace, string = string.split(':')
                                                 type, string = string.split('=')
                                                 buckets, size, string = string.split(',', 2)
@@ -742,31 +785,29 @@ class clGraphiteDaemon(Daemon):
                                                 msg.extend(lines)
                                         except:
                                             print("Failure to get histtype " + histtype + ":")
-                                            print(r)
+                                            print(res)
                                             sys.stdout.flush()
                 except Exception as e:
                     print("Unable to parse namespace list:")
-                    print(r)
+                    print(res)
                     print(e)
                     sys.stdout.flush()
     
             if args.dc:
-                r = -1
+                res = -1
                 # Flatten the list
                 DCS = [ item for sublist in AEROSPIKE_XDR_DCS for item in sublist]
                 for DC in DCS:
                     try:
-                        # xdr stats command changed in server version 5.0
-                        version = self.client.info('build').split('.')
-                        r = ""
+                        res = ""
                         if (int(version[0]) >= 5):
-                            r = self.client.info('get-stats:context=xdr;dc=' + DC)
+                            res = self.client.info('get-stats:context=xdr;dc=' + DC)
                         else:
-                            r = self.client.info('dc/' + DC)
-                        if (-1 != r):
-                            r = r.strip()
+                            res = self.client.info('dc/' + DC)
+                        if (-1 != res):
+                            res = res.strip()
                             lines = []
-                            for string in r.split(';'):
+                            for string in res.split(';'):
                                 if string == "":
                                     continue
     
@@ -784,7 +825,7 @@ class clGraphiteDaemon(Daemon):
                             msg.extend(lines)
                     except Exception as e:
                         print("Unable to parse DC stats:")
-                        print(r)
+                        print(res)
                         print(e)
                         sys.stdout.flush()
     
@@ -796,12 +837,12 @@ class clGraphiteDaemon(Daemon):
     ##        RW = 1 & WO = 0
     
             if args.sindex:
-                r = -1
+                res = -1
                 try:
-                    r = self.client.info('sindex')
-                    if (-1 != r):
-                        r = r.strip()
-                        indexes = str(filter(None, r))
+                    res = self.client.info('sindex')
+                    if (-1 != res):
+                        res = res.strip()
+                        indexes = str(filter(None, res))
                         if len(indexes) > 0:
                             lines = []
                             for index_line in indexes.split(';'):
@@ -821,14 +862,14 @@ class clGraphiteDaemon(Daemon):
                                     lines.append("%s.sindexes.%s.%s.sync_state %s %s" % (GRAPHITE_PATH_PREFIX, index["ns"], index["indexname"], index["sync_state"], now))
                                     lines.append("%s.sindexes.%s.%s.state %s %s" % (GRAPHITE_PATH_PREFIX, index["ns"], index["indexname"], index["state"], now))
     
-                                    r = -1
+                                    res = -1
                                     try:
-                                        r = self.client.info('sindex/' + index["ns"] + '/' + index["indexname"])
+                                        res = self.client.info('sindex/' + index["ns"] + '/' + index["indexname"])
                                     except:
                                         pass
-                                    if (-1 != r):
-                                        r = r.strip()
-                                        for string in r.split(';'):
+                                    if (-1 != res):
+                                        res = res.strip()
+                                        for string in res.split(';'):
                                             name, value = string.split('=')
                                             value = value.replace('false', "0")
                                             value = value.replace('true', "1")
@@ -836,7 +877,7 @@ class clGraphiteDaemon(Daemon):
                             msg.extend(lines)
                 except Exception as e:
                     print("Unable to parse sindex stats:")
-                    print(r)
+                    print(res)
                     print(e)
                     sys.stdout.flush()
 

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -670,6 +670,7 @@ class clGraphiteDaemon(Daemon):
                     if use_latencies_cmd:
                         for cmd in latencies_cmds:
                             if cmd.startswith('latencies:'):
+                                # example response: "batch-index:;{test}-read:;{test}-write:msec,0.0,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00;{test}-udf:"
                                 r = self.client.info(cmd)
                             else:
                                 print("-latency argument is in an incorrect format. Running with argument \"latencies:\" instead.")
@@ -681,6 +682,7 @@ class clGraphiteDaemon(Daemon):
                                 res = res + ';' + r.strip()
                     else:
                         if args.latency.startswith('latency:'):
+                            # example response: "error-no-data-yet-or-back-too-small;{test}-write:19:11:03-GMT,ops/sec,>1ms,>8ms,>64ms;19:11:13,10.0,0.00,0.00,0.00;error-no-data-yet-or-back-too-small"
                             res = self.client.info(latencies_cmds[0])
                         else:
                             print("-latency argument is in an incorrect format. Running with argument \"latency:\" instead.")

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -482,7 +482,7 @@ parser.add_argument("--tls-keyfile"
                     , help="The private keyfile for your client TLS Cert")
 parser.add_argument("--tls-keyfile-pw"
                     , dest="tls_keyfile_pw"
-                    , help="Password to load protected tls_keyfile")
+                    , help="Password to load protected tls-keyfile")
 parser.add_argument("--tls-certfile"
                     , dest="tls_certfile"
                     , help="The client TLS cert")
@@ -504,7 +504,7 @@ parser.add_argument("--tls-cert-blacklist"
 parser.add_argument("--tls-crl-check"
                     , dest="tls_crl_check"
                     , action="store_true"
-                    , help="Checks SSL/TLS certs against vendor's Certificate Revocation Lists for revoked certificates. CRLs are found in path specified by --tls_capath. Checks the leaf certificates only")
+                    , help="Checks SSL/TLS certs against vendor's Certificate Revocation Lists for revoked certificates. CRLs are found in path specified by --tls-capath. Checks the leaf certificates only")
 parser.add_argument("--tls-crl-check-all"
                     , dest="tls_crl_check_all"
                     , action="store_true"

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -494,7 +494,7 @@ parser.add_argument("--tls-capath"
                     , help="The path to a directory containing CA certs and/or CRLs")
 parser.add_argument("--tls-ciphers"
                     , dest="tls_ciphers"
-                    , help="Ciphers to include. See https://www.openssl.org/docs/man1.0.1/apps/ciphers.html for cipher list format")
+                    , help="Ciphers to include. See https://www.openssl.org/docs/man1.1.0/man1/ciphers.html for cipher list format")
 parser.add_argument("--tls-protocols"
                     , dest="tls_protocols"
                     , help="The TLS protocol to use. Available choices: TLSv1, TLSv1.1, TLSv1.2, all. An optional + or - can be appended before the protocol to indicate specific inclusion or exclusion.")
@@ -614,7 +614,7 @@ class clGraphiteDaemon(Daemon):
             msg = []
             now = int(time.time())
 
-            # For checking serer version in order to issue correct commands.
+            # For checking server version in order to issue correct commands.
             version = self.client.info('build').split('.')
 
             res = -1

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -672,8 +672,7 @@ class clGraphiteDaemon(Daemon):
                             if cmd.startswith('latencies:'):
                                 r = self.client.info(cmd)
                             else:
-                                print("-latency argument is in an incorrect format.")
-                                print("Running with argument \"latencies:\" instead.")
+                                print("-latency argument is in an incorrect format. Running with argument \"latencies:\" instead.")
                                 r = self.client.info('latencies:')
 
                             if res == -1:
@@ -684,8 +683,7 @@ class clGraphiteDaemon(Daemon):
                         if args.latency.startswith('latency:'):
                             res = self.client.info(latencies_cmds[0])
                         else:
-                            print("-latency argument is in an incorrect format.")
-                            print("Running with argument \"latency:\" instead.")
+                            print("-latency argument is in an incorrect format. Running with argument \"latency:\" instead.")
                             res = self.client.info('latency:')
                     if (-1 != res):
                         res = res.strip()

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -666,7 +666,7 @@ class clGraphiteDaemon(Daemon):
                 res = -1
                 latencies_cmds = [ item for sublist in AEROSPIKE_LATENCY_CMDS for item in sublist]
                 try:
-                    use_latencies_cmd = int(version[0]) >= 5 and int(version[1]) >= 1
+                    use_latencies_cmd = int(version[0]) > 5 or (int(version[0]) == 5 and int(version[1]) >= 1)
                     if use_latencies_cmd:
                         for cmd in latencies_cmds:
                             if cmd.startswith('latencies:'):

--- a/asgraphite.py
+++ b/asgraphite.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-# Copyright 2013-2019 Aerospike, Inc.
+# Copyright 2013-2020 Aerospike, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 
 __author__ = "Aerospike"
-__copyright__ = "Copyright 2019 Aerospike"
+__copyright__ = "Copyright 2020 Aerospike"
 __version__ = "2.0.0"
 
 # Modules

--- a/grafana/aerospike_dashboard.json
+++ b/grafana/aerospike_dashboard.json
@@ -12,7 +12,7 @@
       "name": "VAR_PREFIX",
       "type": "constant",
       "label": "prefix",
-      "value": "instances",
+      "value": "aerospike",
       "description": ""
     }
   ],
@@ -1851,19 +1851,19 @@
     "list": [
       {
         "current": {
-          "value": "${VAR_prefix}",
-          "text": "${VAR_prefix}"
+          "value": "${VAR_PREFIX}",
+          "text": "${VAR_PREFIX}"
         },
         "hide": 2,
         "label": "",
         "name": "prefix",
         "options": [
           {
-            "value": "${VAR_prefix}",
-            "text": "${VAR_prefix}"
+            "value": "${VAR_PREFIX}",
+            "text": "${VAR_PREFIX}"
           }
         ],
-        "query": "${VAR_prefix}",
+        "query": "${VAR_PREFIX}",
         "type": "constant"
       },
       {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 argparse
-aerospike==3.7.1
+aerospike==3.10.0


### PR DESCRIPTION
This PR is apart of the larger effort to update monitoring plugins to be up-to-date with the latest aerospike server releases.  Currently, this is 5.1.  This also includes backward compatibility with 5.0 and 4.9.

JIRA: https://aerospike.atlassian.net/browse/TOOLS-1544, https://aerospike.atlassian.net/browse/TOOLS-1533

The following changes were made:
  1. Update plugin to use python3/client 3.10
  1. Update readme with current usage info
  1. Adding support for new xdr stats ("get-stats:xdr;context=DC") and new "latencies:" cmd
  1. Fixing typo in Grafana dashboard template to be working "out of the box"
  1. renaming some variables for readability